### PR TITLE
Abstract formatting helpers, format updates

### DIFF
--- a/bin/parse.js
+++ b/bin/parse.js
@@ -6,9 +6,10 @@ const options = yargs
   .argv;
 const args = options._;
 
+const ast = require('../ast');
 const concat = require('concat-stream');
-const parse = require('../parse');
 const format = require('../format');
+const parse = require('../parse');
 
 var fmt = node => JSON.stringify(node, null, '  ');
 
@@ -21,7 +22,10 @@ if (options.format) {
 if (args.length) {
   args.forEach(filename => {
     parse.file(filename, (error, node) => {
-      console.log(filename, '=>\n', fmt(ast));
+      if (!options.format) {
+        node = ast.normalize(node);
+      }
+      console.log(filename, '=>\n', fmt(node));
     });
   });
 } else {

--- a/format/abstract.js
+++ b/format/abstract.js
@@ -66,9 +66,11 @@ const LookupVal = function(node) {
     stack.unshift(target.val.value);
     target = target.target;
   }
-  const str = (this.VAR_PREFIX || '') + target.value;
-  return stack.reduce((str, symbol) => {
-    return str + this.accessor(symbol);
+  const str = this.VAR_PREFIX
+    ? this.VAR_PREFIX + target.value
+    : target.value;
+  return stack.reduce((_, symbol) => {
+    return _ + this.accessor(symbol);
   }, str);
 };
 

--- a/format/abstract.js
+++ b/format/abstract.js
@@ -57,6 +57,8 @@ const For = function(node) {
 const LookupVal = function(node) {
   invariant(typeof this.quote === 'function',
             'Encountered LookupVal without quote() method');
+  invariant(typeof this.accessor === 'function',
+            'Encountered LookupVal without accessor() method');
 
   const stack = [node.val.value];
   var target = node.target;
@@ -64,12 +66,17 @@ const LookupVal = function(node) {
     stack.unshift(target.val.value);
     target = target.target;
   }
+  const str = (this.VAR_PREFIX || '') + target.value;
   return stack.reduce((str, symbol) => {
-    const out = this.quote(symbol);
-    return /^[0-9'"]/.test(out)
-      ? str + '[' + out + ']'
-      : str + '.' + out;
-  }, target.value);
+    return str + this.accessor(symbol);
+  }, str);
+};
+
+const accessor = function(symbol) {
+  const str = this.quote(symbol)
+  return /^[0-9'"]/.test(str)
+    ? '[' + str + ']'
+    : '.' + str;
 };
 
 const Literal = function(node) {
@@ -161,6 +168,7 @@ module.exports = {
 
   // abstract word quoting helper
   quote:        quote,
+  accessor:     accessor,
 
   Compare:      Compare,
   If:           If,

--- a/format/abstract.js
+++ b/format/abstract.js
@@ -1,5 +1,10 @@
+'use strict';
+const invariant = require('invariant');
 
 const If = function(node) {
+  invariant(this.K_IF, 'Encountered If without K_IF');
+  invariant(this.K_END_IF, 'Encountered If without K_END_IF');
+
   const parts = [
     this.C_OPEN, this.WS,
     this.K_IF, this.WS,
@@ -9,6 +14,7 @@ const If = function(node) {
   ];
 
   if (node.else_) {
+    invariant(this.K_ELSE, 'Encountered If..Else without K_ELSE');
     // TODO: produce elseif expressions, rather than nested if/else
     parts.push(
       this.C_OPEN, this.WS,
@@ -25,6 +31,10 @@ const If = function(node) {
 };
 
 const For = function(node) {
+  invariant(this.K_FOR, 'Encountered For..In without K_FOR');
+  invariant(this.K_FOR_IN, 'Encountered For..In without K_FOR_IN');
+  invariant(this.K_END_FOR, 'Encountered For..In without K_END_FOR');
+
   const parts = [
     this.C_OPEN, this.WS,
     this.K_FOR, this.WS,
@@ -45,14 +55,17 @@ const For = function(node) {
 };
 
 const LookupVal = function(node) {
+  invariant(typeof this.quote === 'function',
+            'Encountered LookupVal without quote() method');
+
+  const stack = [node.val.value];
   var target = node.target;
-  var stack = [node.val.value];
   while (target.type === 'LookupVal') {
     stack.unshift(target.val.value);
     target = target.target;
   }
   return stack.reduce((str, symbol) => {
-    var out = this.quote(symbol);
+    const out = this.quote(symbol);
     return /^[0-9'"]/.test(out)
       ? str + '[' + out + ']'
       : str + '.' + out;
@@ -86,7 +99,7 @@ const TemplateData = function(node) {
   return node.value;
 };
 
-const Symbol = function(node, parent) {
+const Symbol = function(node) {
   return node.value;
 };
 
@@ -99,6 +112,11 @@ const Compare = function(node) {
 };
 
 const quote = function(symbol, force) {
+  invariant(this.P_NUMERIC instanceof RegExp,
+            'quote() requires P_NUMERIC regexp');
+  invariant(this.P_WORD instanceof RegExp,
+            'quote() requires P_WORD regexp');
+
   if (this.P_NUMERIC.test(symbol)) {
     return symbol;
   }

--- a/format/abstract.js
+++ b/format/abstract.js
@@ -1,0 +1,158 @@
+
+const If = function(node) {
+  const parts = [
+    this.C_OPEN, this.WS,
+    this.K_IF, this.WS,
+    this.node(node.cond), this.WS,
+    this.C_CLOSE,
+    this.node(node.body)
+  ];
+
+  if (node.else_) {
+    // TODO: produce elseif expressions, rather than nested if/else
+    parts.push(
+      this.C_OPEN, this.WS,
+      this.K_ELSE, this.WS,
+      this.C_CLOSE,
+      this.node(node.else_)
+    );
+  }
+  return parts.concat([
+    this.C_OPEN, this.WS,
+    this.K_END_IF, this.WS,
+    this.C_CLOSE
+  ]).join('');
+};
+
+const For = function(node) {
+  const parts = [
+    this.C_OPEN, this.WS,
+    this.K_FOR, this.WS,
+    this.node(node.name), this.WS,
+    this.K_FOR_IN, this.WS,
+    this.node(node.arr), this.WS,
+    this.C_CLOSE
+  ];
+
+  // TODO: node.else_
+
+  return parts.concat([
+    this.node(node.body),
+    this.C_OPEN, this.WS,
+    this.K_END_FOR, this.WS,
+    this.C_CLOSE
+  ]).join('');
+};
+
+const LookupVal = function(node) {
+  var target = node.target;
+  var stack = [node.val.value];
+  while (target.type === 'LookupVal') {
+    stack.unshift(target.val.value);
+    target = target.target;
+  }
+  return stack.reduce((str, symbol) => {
+    var out = this.quote(symbol);
+    return /^[0-9'"]/.test(out)
+      ? str + '[' + out + ']'
+      : str + '.' + out;
+  }, target.value);
+};
+
+const Literal = function(node) {
+  return this.quote(node.value, true);
+};
+
+const Output = function(node) {
+  return node.children.map(child => {
+    var out = this.node(child, node);
+    if (child.type === 'TemplateData') {
+      return out;
+    } else {
+      return [
+        this.O_OPEN, this.WS,
+        out, this.WS,
+        this.O_CLOSE
+      ].join('');
+    }
+  }).join(this.WS || '');
+};
+
+const NodeList = function(node) {
+  return node.children.map(child => this.node(child)).join('');
+};
+
+const TemplateData = function(node) {
+  return node.value;
+};
+
+const Symbol = function(node, parent) {
+  return node.value;
+};
+
+const Compare = function(node) {
+  return [
+    this.node(node.expr),
+    node.ops[0].type,
+    this.node(node.ops[0].expr, node)
+  ].join(' ');
+};
+
+const quote = function(symbol, force) {
+  if (this.P_NUMERIC.test(symbol)) {
+    return symbol;
+  }
+  return (!force && this.P_WORD.test(symbol))
+    ? symbol
+    : "'" + symbol.replace(/'/g, "\\'") + "'";
+};
+
+module.exports = {
+  // output open delimiter
+  O_OPEN:       '{{',
+  // output close delimiter
+  O_CLOSE:      '}}',
+
+  // control structure open
+  C_OPEN:       '{% ',
+  // control structure close
+  C_CLOSE:      '%}',
+  // whitespace around control structures
+  C_WS:         ' ',
+
+  // if keyword
+  K_IF:         null,
+  // else keyword
+  K_ELSE:       null,
+  // else if keyword
+  K_ELSE_IF:    null,
+  // end if
+  K_END_IF:     null,
+
+  // for/foreach/each keyword
+  K_FOR:        null,
+  // for..in "in" keyword
+  K_FOR_IN:     null,
+  // end for/foreach/each
+  K_END_FOR:    null,
+
+  // regex matching numeric expressions
+  P_NUMERIC:    /^\d+(\.\d+)?$/,
+  // regex matching bare words (not requiring quotes)
+  P_WORD:       /^[a-z]\w*$/i,
+
+  // abstract word quoting helper
+  quote:        quote,
+
+  Compare:      Compare,
+  If:           If,
+
+  For:          For,
+  Literal:      Literal,
+  LookupVal:    LookupVal,
+  NodeList:     NodeList,
+  Output:       Output,
+  Root:         NodeList,
+  Symbol:       Symbol,
+  TemplateData: TemplateData
+};

--- a/format/abstract.js
+++ b/format/abstract.js
@@ -69,16 +69,9 @@ const LookupVal = function(node) {
   const str = this.VAR_PREFIX
     ? this.VAR_PREFIX + target.value
     : target.value;
-  return stack.reduce((_, symbol) => {
-    return _ + this.accessor(symbol);
+  return stack.reduce((out, symbol) => {
+    return out + this.accessor(symbol);
   }, str);
-};
-
-const accessor = function(symbol) {
-  const str = this.quote(symbol)
-  return /^[0-9'"]/.test(str)
-    ? '[' + str + ']'
-    : '.' + str;
 };
 
 const Literal = function(node) {
@@ -132,6 +125,13 @@ const quote = function(symbol, force) {
   return (!force && this.P_WORD.test(symbol))
     ? symbol
     : "'" + symbol.replace(/'/g, "\\'") + "'";
+};
+
+const accessor = function(symbol) {
+  const str = this.quote(symbol)
+  return /^[0-9'"]/.test(str)
+    ? '[' + str + ']'
+    : '.' + str;
 };
 
 module.exports = {

--- a/format/aliases.js
+++ b/format/aliases.js
@@ -1,0 +1,9 @@
+/**
+ * This object defines alias mappings for various formats, including
+ * well-known filename extensions.
+ */
+module.exports = {
+  hbs:    'handlebars',
+  jekyll: 'liquid',
+  njk:    'nunjucks',
+};

--- a/format/factory.js
+++ b/format/factory.js
@@ -1,17 +1,14 @@
 'use strict';
+const assign = require('object-assign');
 
 const factory = (formatters) => {
-  const formats = Object.assign(
-    {},
-    formatters
-  );
+  const formats = assign({}, formatters);
 
-  const formatNode = function(node, parent) {
+  const formatNode = function(node) {
     var format = formats[node.type];
     switch (typeof format) {
       case 'function':
-        // XXX set node.parent here?
-        return format.call(formats, node, parent);
+        return format.call(formats, node);
       default:
         throw new Error('Unsupported node type found: "' + node.type + '"');
     }

--- a/format/handlebars.js
+++ b/format/handlebars.js
@@ -1,0 +1,147 @@
+'use strict';
+const abs = require('./abstract');
+const invariant = require('invariant');
+const formatFactory = require('./factory');
+
+const If = function(node) {
+  invariant(node.cond.type === 'Symbol' ||
+            node.cond.type === 'LookupVal',
+            'Encountered If with unexpected condition type: "' +
+              node.cond.type + '" (expected Symbol or LookupVal)');
+
+  this._context.unshift(node.cond);
+
+  const parts = [
+    this.C_OPEN,
+    this.K_IF, this.WS,
+    this.node(node.cond),
+    this.C_CLOSE,
+    this.node(node.body)
+  ];
+
+  this._context.shift();
+
+  if (node.else_) {
+    parts.push(
+      this.C_OPEN,
+      this.K_ELSE,
+      this.C_CLOSE,
+      this.node(node.else_)
+    );
+  }
+
+  parts.push(
+    this.C_OPEN,
+    this.K_END_IF,
+    this.C_CLOSE
+  );
+  
+  return parts.join('');
+};
+
+const For = function(node) {
+
+  this._context.unshift(node.name);
+
+  const parts = [
+    '{{#each ',
+    this.node(node.arr),
+    '}}',
+    this.node(node.body)
+  ];
+
+  this._context.shift();
+
+  parts.push('{{/each}}');
+
+  return parts.join('');
+};
+
+const Symbol = abs.Symbol;
+
+const LookupVal = function(node) {
+
+  const stack = [node.val.value];
+  var target = node.target;
+  while (target.type === 'LookupVal') {
+    stack.unshift(target.val.value);
+    target = target.target;
+  }
+  stack.unshift(target.value);
+
+  /**
+   * FIXME: this loop is meant to "trim" leading symbols in a lookup
+   * if the same symbols match the beginning of our context stack, as in:
+   *
+   * {% for y in x %}hi {{ y.z }}{% endfor %}
+   *
+   * should translate to:
+   *
+   * {{#each x}}hi {{z}}{{/each}}
+   *
+   * It doesn't do nearly the right thing... yet.
+   */
+  var i = 0;
+  while (this._context[i] && stack[0] === this._context[i].value) {
+    stack.shift();
+    i++;
+  }
+
+  return stack.reduce((out, symbol) => {
+    return out + this.accessor(symbol);
+  }, stack.shift());
+};
+
+const quote = function(symbol) {
+  // symbols are never quoted, even in accessor expressions
+  return symbol;
+};
+
+const accessor = function(symbol) {
+  // any valid JavaScript identifier just gets a leading ".";
+  // otherwise, we "escape" the symbol with brackets
+  return this.P_IDENTIFIER.test(symbol)
+    ? '.' + symbol
+    : '.[' + symbol + ']';
+};
+
+module.exports = formatFactory({
+  WS:           '',
+
+  // note that our control structure open and close delimiters
+  // do *not* include the leading #, since some keyword equivalents
+  // do not use it ("^" for else, etc.)
+  C_OPEN:       '{{',
+  C_CLOSE:      '}}',
+  // for parity with other templating systems,
+  // output should *not* be HTML-escaped (double curlies)
+  O_OPEN:       '{{{',
+  O_CLOSE:      '}}}',
+
+  K_IF:         '#if ',
+  K_ELSE:       '^',
+  K_END_IF:     '/if',
+
+  K_EACH:       '#each ',
+  K_END_EACH:   '/each',
+
+  If:           If,
+  For:          For,
+
+  // current symbol context
+  _context:     [],
+
+  // regex matching bare words (not requiring quotes)
+  P_IDENTIFIER: /^[a-z]\w*$/i,
+
+  quote:        quote,
+  accessor:     accessor,
+
+  LookupVal:    LookupVal,
+  NodeList:     abs.NodeList,
+  Output:       abs.Output,
+  Root:         abs.Root,
+  Symbol:       Symbol,
+  TemplateData: abs.TemplateData,
+
+});

--- a/format/index.js
+++ b/format/index.js
@@ -1,7 +1,12 @@
 'use strict';
 const formatFactory = require('./factory');
+const aliases = require('./aliases');
 
 const getFormat = function(name, overrides) {
+  if (name in aliases) {
+    name = aliases[name];
+  }
+
   var fmt;
   try {
     fmt = require('./' + name);

--- a/format/liquid.js
+++ b/format/liquid.js
@@ -1,20 +1,52 @@
 'use strict';
-const nunjucks = require('./nunjucks');
+const formatFactory = require('./factory');
+const abs = require('./abstract');
 
-module.exports = nunjucks.extend({
-  // Nunjucks/Jinja: {{ foo | bar(baz, 1) }}
-  // Liquid: {{ foo | bar: baz, 1 }}
-  Filter: function(node) {
-    var args = node.args.children;
-    return [
-      this.node(args[0]),
-      ' | ',
-      this.node(node.name),
-      args.length > 1
-        ? ': ' + args.slice(1)
-            .map(arg => this.node(arg))
-            .join(', ')
-        : ''
-    ].join('');
-  }
+const Filter = function(node) {
+  const args = node.args.children;
+  const rest = args.length > 1
+    ? ': ' + args.slice(1)
+        .map(arg => this.node(arg))
+        .join(', ')
+    : '';
+  return [
+    this.node(args[0]), this.WS,
+    this.FILTER_DELIM, this.WS,
+    this.node(node.name),
+    rest
+  ].join('');
+};
+
+module.exports = formatFactory({
+  WS:           ' ',
+  K_IF:         'if',
+  K_ELSE:       'else',
+  K_ELSE_IF:    'elsif',
+  K_END_IF:     'endif',
+  K_FOR:        'for',
+  K_END_FOR:    'endfor',
+  K_FOR_IN:     'in',
+
+  C_OPEN:       '{%',
+  C_CLOSE:      '%}',
+  O_OPEN:       '{{',
+  O_CLOSE:      '}}',
+
+  P_NUMERIC:    abs.P_NUMERIC,
+  P_WORD:       abs.P_WORD,
+
+  FILTER_DELIM: '|',
+
+  quote:        abs.quote,
+  Compare:      abs.Compare,
+  If:           abs.If,
+  Filter:       Filter,
+  For:          abs.For,
+  Literal:      abs.Literal,
+  LookupVal:    abs.LookupVal,
+  NodeList:     abs.NodeList,
+  Output:       abs.Output,
+  Root:         abs.NodeList,
+  Symbol:       abs.Symbol,
+  TemplateData: abs.TemplateData
 });

--- a/format/liquid.js
+++ b/format/liquid.js
@@ -42,7 +42,9 @@ module.exports = formatFactory({
   // quote patterns
   P_NUMERIC:    abs.P_NUMERIC,
   P_WORD:       abs.P_WORD,
+
   quote:        abs.quote,
+  accessor:     abs.accessor,
 
   Compare:      abs.Compare,
   If:           abs.If,

--- a/format/liquid.js
+++ b/format/liquid.js
@@ -18,7 +18,10 @@ const Filter = function(node) {
 };
 
 module.exports = formatFactory({
+  // whitespace
   WS:           ' ',
+
+  // keywords
   K_IF:         'if',
   K_ELSE:       'else',
   K_ELSE_IF:    'elsif',
@@ -27,17 +30,20 @@ module.exports = formatFactory({
   K_END_FOR:    'endfor',
   K_FOR_IN:     'in',
 
+  // control structure delimiters
   C_OPEN:       '{%',
   C_CLOSE:      '%}',
+  // output delimiters
   O_OPEN:       '{{',
   O_CLOSE:      '}}',
 
-  P_NUMERIC:    abs.P_NUMERIC,
-  P_WORD:       abs.P_WORD,
-
   FILTER_DELIM: '|',
 
+  // quote patterns
+  P_NUMERIC:    abs.P_NUMERIC,
+  P_WORD:       abs.P_WORD,
   quote:        abs.quote,
+
   Compare:      abs.Compare,
   If:           abs.If,
   Filter:       Filter,

--- a/format/nunjucks.js
+++ b/format/nunjucks.js
@@ -38,6 +38,8 @@ module.exports = formatFactory({
   FILTER_DELIM: '|',
 
   quote:        abs.quote,
+  accessor:     abs.accessor,
+
   Compare:      abs.Compare,
   If:           abs.If,
   Filter:       Filter,

--- a/format/nunjucks.js
+++ b/format/nunjucks.js
@@ -3,16 +3,17 @@ const formatFactory = require('./factory');
 const abs = require('./abstract');
 
 const Filter = function(node) {
-  var args = node.args.children;
+  const args = node.args.children;
+  const rest = args.length > 1
+    ? '(' + args.slice(1)
+        .map(arg => this.node(arg))
+        .join(', ') + ')'
+    : '';
   return [
     this.node(args[0]), this.WS,
     this.FILTER_DELIM, this.WS,
     this.node(node.name),
-    args.length > 1
-      ? '(' + args.slice(1)
-          .map(arg => this.node(arg))
-          .join(', ') + ')'
-      : ''
+    rest
   ].join('');
 };
 

--- a/format/nunjucks.js
+++ b/format/nunjucks.js
@@ -1,93 +1,12 @@
 'use strict';
 const formatFactory = require('./factory');
-
-const PATTERN_NUMERIC = /^\d+(\.\d+)?$/;
-const PATTERN_WORD = /^[a-z]\w*$/i;
-
-const If = function(node) {
-  const parts = [
-    this.CTRL_START, ' if ', this.node(node.cond), ' ', this.CTRL_END,
-    this.node(node.body)
-  ];
-  if (node.else_) {
-    // TODO: produce elseif expressions, rather than nested if/else
-    parts.push(
-      this.CTRL_START, ' else ', this.CTRL_END,
-      this.node(node.else_)
-    );
-  }
-  return parts.concat([
-    this.CTRL_START, ' endif ', this.CTRL_END
-  ]).join('');
-};
-
-const For = function(node) {
-  const parts = [
-    this.CTRL_START, ' for ', this.node(node.name),
-    ' in ', this.node(node.arr), ' ', this.CTRL_END
-  ];
-
-  // TODO: node.else_
-
-  return parts.concat([
-    this.node(node.body),
-    this.CTRL_START, ' endfor ', this.CTRL_END
-  ]).join('');
-};
-
-const LookupVal = function(node) {
-  var target = node.target;
-  var stack = [node.val.value];
-  while (target.type === 'LookupVal') {
-    stack.unshift(target.val.value);
-    target = target.target;
-  }
-  return stack.reduce((str, symbol) => {
-    var out = this.quote(symbol);
-    return /^[0-9'"]/.test(out)
-      ? str + '[' + out + ']'
-      : str + '.' + out;
-  }, target.value);
-};
-
-const Literal = function(node) {
-  return this.quote(node.value, true);
-};
-
-const Output = function(node) {
-  return node.children.map(child => {
-    var out = this.node(child, node);
-    return child.type === 'TemplateData'
-      ? out
-      : [this.VAR_START, out, this.VAR_END].join(' ');
-  }).join('');
-};
-
-const NodeList = function(node) {
-  return node.children.map(child => this.node(child)).join('');
-};
-
-const TemplateData = function(node) {
-  return node.value;
-};
-
-const Symbol = function(node, parent) {
-  return node.value;
-};
-
-const Compare = function(node) {
-  return [
-    this.node(node.expr),
-    node.ops[0].type,
-    this.node(node.ops[0].expr, node)
-  ].join(' ');
-};
+const abs = require('./abstract');
 
 const Filter = function(node) {
   var args = node.args.children;
   return [
-    this.node(args[0]),
-    ' | ',
+    this.node(args[0]), this.WS,
+    this.FILTER_DELIM, this.WS,
     this.node(node.name),
     args.length > 1
       ? '(' + args.slice(1)
@@ -97,30 +16,36 @@ const Filter = function(node) {
   ].join('');
 };
 
-const quote = function(symbol, force) {
-  if (PATTERN_NUMERIC.test(symbol)) {
-    return symbol;
-  }
-  return (!force && PATTERN_WORD.test(symbol))
-    ? symbol
-    : "'" + symbol.replace(/'/g, "\\'") + "'";
-};
-
 module.exports = formatFactory({
-  CTRL_START:   '{%',
-  CTRL_END:     '%}',
-  VAR_START:    '{{',
-  VAR_END:      '}}',
-  quote:        quote,
-  Compare:      Compare,
-  If:           If,
+  WS:           ' ',
+  K_IF:         'if',
+  K_ELSE:       'else',
+  K_ELSE_IF:    'elsif',
+  K_END_IF:     'endif',
+  K_FOR:        'for',
+  K_END_FOR:    'endfor',
+  K_FOR_IN:     'in',
+
+  C_OPEN:       '{%',
+  C_CLOSE:      '%}',
+  O_OPEN:       '{{',
+  O_CLOSE:      '}}',
+
+  P_NUMERIC:    abs.P_NUMERIC,
+  P_WORD:       abs.P_WORD,
+
+  FILTER_DELIM: '|',
+
+  quote:        abs.quote,
+  Compare:      abs.Compare,
+  If:           abs.If,
   Filter:       Filter,
-  For:          For,
-  Literal:      Literal,
-  LookupVal:    LookupVal,
-  NodeList:     NodeList,
-  Output:       Output,
-  Root:         NodeList,
-  Symbol:       Symbol,
-  TemplateData: TemplateData
+  For:          abs.For,
+  Literal:      abs.Literal,
+  LookupVal:    abs.LookupVal,
+  NodeList:     abs.NodeList,
+  Output:       abs.Output,
+  Root:         abs.NodeList,
+  Symbol:       abs.Symbol,
+  TemplateData: abs.TemplateData
 });

--- a/format/php.js
+++ b/format/php.js
@@ -1,6 +1,7 @@
 'use strict';
 const formatFactory = require('./factory');
 const abs = require('./abstract');
+const ast = require('../ast');
 
 const If = function(node) {
   const parts = [
@@ -45,8 +46,8 @@ const For = function(node) {
   ]).join('');
 };
 
-const Symbol = function(node, parent) {
-  const prefix = parent && parent.type === 'Filter'
+const Symbol = function(node) {
+  const prefix = node.parent && ast.getNodeType(node.parent) === 'Filter'
     ? ''
     : this.VAR_PREFIX;
   return prefix + node.value;
@@ -63,14 +64,27 @@ const Filter = function(node) {
   ].join('');
 };
 
+const accessor = function(symbol) {
+  return '[' + this.quote(symbol, true) + ']';
+};
+
 module.exports = formatFactory({
   WS:           ' ',
-  VAR_PREFIX:   '$',
+
   C_OPEN:       '<?php',
   C_CLOSE:      '?>',
+
   O_OPEN:       '<?=',
   O_CLOSE:      '?>',
+
+  VAR_PREFIX:   '$',
+
+  P_NUMERIC:    abs.P_NUMERIC,
+  P_WORD:       abs.P_WORD,
+
   quote:        abs.quote,
+  accessor:     accessor,
+
   Compare:      abs.Compare,
   If:           If,
   Filter:       Filter,

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "CC0-1.0",
   "dependencies": {
     "concat-stream": "^1.5.2",
+    "invariant": "^2.2.1",
     "nunjucks": "^2.5.2",
     "yargs": "^6.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "concat-stream": "^1.5.2",
     "invariant": "^2.2.1",
     "nunjucks": "^2.5.2",
+    "object-assign": "^4.1.0",
     "yargs": "^6.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The bulk of this update is a new collection of "abstract" formatting helpers in `format/abstract.js`, which does not export a format that can be extended, but instead provides functions and constants that should be useful in lots of different outputs. The goal here was to avoid going any further down the inheritance hole with the Nunjucks format serving as the base "class" for all others. Instead, what we have now is a collection of functions (and values, such as useful regular expressions) that each format can use as it sees fit.

I also fixed up the PHP format and started working on a new Handlebars one for shits and giggles. There are no tests for formats other than Nunjucks yet. 😢 