### PR TITLE
Add basic ERB formatter

### DIFF
--- a/format/abstract.js
+++ b/format/abstract.js
@@ -108,6 +108,14 @@ const NodeList = function(node) {
   return node.children.map(child => this.node(child)).join('');
 };
 
+const Not = function(node) {
+  return [
+      this.K_NOT,
+      this.WS,
+      this.node(node.target)
+  ].join('');
+};
+
 const TemplateData = function(node) {
   return node.value;
 };
@@ -238,6 +246,8 @@ module.exports = {
   K_ELSE_IF:    null,
   // end if
   K_END_IF:     null,
+  // not operator
+  K_NOT:        null,
 
   // for/foreach/each keyword
   K_FOR:        null,
@@ -266,6 +276,7 @@ module.exports = {
   Literal:      Literal,
   LookupVal:    LookupVal,
   NodeList:     NodeList,
+  Not:          Not,
   Operator:     Operator,
   Output:       Output,
   Root:         NodeList,

--- a/format/erb.js
+++ b/format/erb.js
@@ -1,0 +1,91 @@
+'use strict';
+const formatFactory = require('./factory');
+const abs = require('./abstract');
+const ast = require('../ast');
+
+const Include = function(node) {
+  return [
+    this.O_OPEN, this.WS,
+    this.K_INCLUDE, this.WS,
+    this.node(node.template), this.WS,
+    this.C_CLOSE
+  ].join('');
+};
+
+const Filter = function(node) {
+  return [
+      this.node(node.name),
+      '(',
+      node.args.children.map(arg => this.node(arg)).join(', '),
+      ')'
+  ].join('');
+};
+
+const For = function(node) {
+  const parts = [
+    this.C_OPEN, this.WS,
+    this.node(node.arr),
+    '.each do |',
+    this.node(node.name),
+    '|', this.WS,
+    this.C_CLOSE
+  ];
+
+  return parts.concat([
+    this.node(node.body),
+    this.C_OPEN, this.WS,
+    this.K_END_FOR, this.WS,
+    this.C_CLOSE
+  ]).join('');
+};
+
+const Set = function(node) {
+  return [
+    this.C_OPEN, this.WS,
+    this.node(node.targets[0]), this.WS,
+    '=', this.WS,
+    this.node(node.value), this.WS,
+    this.C_CLOSE
+  ].join('');
+};
+
+module.exports = formatFactory({
+  WS:           ' ',
+
+  K_IF:         'if',
+  K_ELSE:       'else',
+  K_ELSE_IF:    'elsif',       // NB: 'elseif' is also allowed
+  K_END_IF:     'end',
+  K_END_FOR:     'end',
+  K_INCLUDE:    'render partial:',
+
+  C_OPEN:       '<%',
+  C_CLOSE:      '%>',
+  O_OPEN:       '<%=',
+  O_CLOSE:      '%>',
+
+  P_NUMERIC:    abs.P_NUMERIC,
+  P_WORD:       abs.P_WORD,
+
+  quote:        abs.quote,
+  accessor:     abs.accessor,
+
+  Add:          abs.Operator('+'),
+  Compare:      abs.Compare,
+  Div:          abs.Operator('/'),
+  Filter:       Filter,
+  For:          For,
+  If:           abs.If,
+  Include:      Include,
+  Group:        abs.Group,
+  Literal:      abs.Literal,
+  LookupVal:    abs.LookupVal,
+  Mul:          abs.Operator('*'),
+  NodeList:     abs.NodeList,
+  Output:       abs.Output,
+  Root:         abs.NodeList,
+  Set:          Set,
+  Sub:          abs.Operator('-'),
+  Symbol:       abs.Symbol,
+  TemplateData: abs.TemplateData
+});

--- a/format/erb.js
+++ b/format/erb.js
@@ -56,6 +56,7 @@ module.exports = formatFactory({
   K_ELSE:       'else',
   K_ELSE_IF:    'elsif',       // NB: 'elseif' is also allowed
   K_END_IF:     'end',
+  K_NOT:        'not',
   K_END_FOR:     'end',
   K_INCLUDE:    'render partial:',
 
@@ -82,6 +83,7 @@ module.exports = formatFactory({
   LookupVal:    abs.LookupVal,
   Mul:          abs.Operator('*'),
   NodeList:     abs.NodeList,
+  Not:          abs.Not,
   Output:       abs.Output,
   Root:         abs.NodeList,
   Set:          Set,

--- a/format/handlebars.js
+++ b/format/handlebars.js
@@ -4,11 +4,20 @@ const invariant = require('invariant');
 const formatFactory = require('./factory');
 
 const If = function(node) {
-  this._chomp(node.cond);
+  let K_IF = this.K_IF;
+
+  if (node.cond.type == 'Not') {
+    K_IF = this.K_IF_NOT
+    this._chomp(node.cond.target);
+  }
+  else {
+    this._chomp(node.cond);
+  }
+
 
   const parts = [
     this.C_OPEN,
-    this.K_IF, this.WS,
+    K_IF, this.WS,
     this.node(node.cond),
     this.C_CLOSE,
     this.node(node.body)
@@ -30,7 +39,7 @@ const If = function(node) {
     this.K_END_IF,
     this.C_CLOSE
   );
-  
+
   return parts.join('');
 };
 
@@ -151,7 +160,8 @@ module.exports = formatFactory({
   O_CLOSE:      '}}}',
 
   K_IF:         '#if ',
-  K_ELSE:       '^',
+  K_IF_NOT:     '^if ',
+  K_ELSE:       'else',
   K_END_IF:     '/if',
 
   K_EACH:       '#each ',
@@ -174,6 +184,7 @@ module.exports = formatFactory({
   Literal:      abs.Literal,
   LookupVal:    LookupVal,
   NodeList:     abs.NodeList,
+  Not:          abs.Not,
   Output:       abs.Output,
   Root:         abs.Root,
   Symbol:       Symbol,

--- a/format/index.js
+++ b/format/index.js
@@ -29,4 +29,5 @@ module.exports = {
   jinja: require('./jinja'),
   handlebars: require('./handlebars'),
   php: require('./php'),
+  erb: require('./erb'),
 };

--- a/format/nunjucks.js
+++ b/format/nunjucks.js
@@ -47,6 +47,7 @@ module.exports = formatFactory({
   K_ELSE:       'else',
   K_ELSE_IF:    'elif',       // NB: 'elseif' is also allowed
   K_END_IF:     'endif',
+  K_NOT:        'not',
   K_FOR:        'for',
   K_END_FOR:    'endfor',
   K_FOR_IN:     'in',
@@ -85,6 +86,7 @@ module.exports = formatFactory({
   LookupVal:    abs.LookupVal,
   Mul:          abs.Operator('*'),
   NodeList:     abs.NodeList,
+  Not:          abs.Not,
   Or:           abs.Operator('or'),
   Output:       abs.Output,
   Root:         abs.NodeList,

--- a/test/erb.spec.js
+++ b/test/erb.spec.js
@@ -1,0 +1,207 @@
+'use strict';
+const assert = require('./assert');
+const parse = require('../parse');
+const format = require('../format');
+
+before(function() {
+  const opts = {
+    clean: true
+  };
+  this.parse = str => parse.string(str, opts);
+  this.format = format.erb;
+});
+
+
+describe('default format (nunjucks -> erb)', function() {
+
+  describe('formats output expressions', function() {
+    assert.formatEquals(
+      "foo {{ bar }} baz",
+      "foo <%= bar %> baz"
+    );
+
+    assert.formatEquals(
+      "foo {{ bar }} baz {{ qux[0] }}",
+      "foo <%= bar %> baz <%= qux[0] %>"
+    );
+    assert.formatEquals(
+      "foo {{ bar['baz qux'][1].x }}",
+      "foo <%= bar['baz qux'][1].x %>"
+    );
+  });
+
+  describe('formats filter tags', function() {
+    assert.formatEquals(
+      "foo {{ bar | qux }} baz",
+      "foo <%= qux(bar) %> baz"
+    );
+    assert.formatEquals(
+      "foo {{ bar | qux(1) }} baz",
+      "foo <%= qux(bar, 1) %> baz"
+    );
+    assert.formatEquals(
+      "foo {{ bar | qux(1, 'quux', bar.baz[0]) }} baz",
+      "foo <%= qux(bar, 1, 'quux', bar.baz[0]) %> baz"
+    );
+  });
+
+  describe('formats for..in loops', function() {
+    assert.formatEquals(
+      "{% for x in items %}la {{ x[0] }}{% endfor %}",
+      "<% items.each do |x| %>la <%= x[0] %><% end %>"
+    );
+    assert.formatEquals(
+      "{% for x in items.x['foo bar'].qux %}la {{ x[0] }}{% endfor %}",
+      "<% items.x['foo bar'].qux.each do |x| %>la <%= x[0] %><% end %>"
+    );
+  });
+
+  describe('formats if conditionals', function() {
+    assert.formatEquals(
+      "{% if z %}yes{% endif %}",
+      "<% if z %>yes<% end %>"
+    );
+    assert.formatEquals(
+      "{% if z == 'bar' %}yes{% endif %}",
+      "<% if z == 'bar' %>yes<% end %>"
+    );
+    assert.formatEquals(
+      "{% if z %}yes{% else %}no{% endif %}",
+      "<% if z %>yes<% else %>no<% end %>"
+    );
+
+    // @TODO: add `elsif` support
+    assert.formatEquals(
+      "{% if z %}yes{% elseif y %}maybe{% else %}no{% endif %}",
+      "<% if z %>yes<% else %><% if y %>maybe<% else %>no<% end %><% end %>"
+    );
+    assert.formatEquals(
+      "{% if z %}yes{% else %}{% if y %}maybe{% else %}no{% endif %}{% endif %}",
+      "<% if z %>yes<% else %><% if y %>maybe<% else %>no<% end %><% end %>"
+    );
+  });
+
+  describe('literals', function() {
+    it('does not quote true, false, or null', function() {
+      assert.formatEquals(
+        "{{ true }}",
+        "<%= true %>"
+      );
+      assert.formatEquals(
+        "{{ false }}",
+        "<%= false %>"
+      );
+      assert.formatEquals(
+        "{{ null }}",
+        "<%= null %>"
+      );
+    });
+  });
+
+  describe('operators', function() {
+    describe('add', function() {
+      assert.formatEquals(
+        "{{ foo + bar }}",
+        "<%= foo + bar %>"
+      );
+      assert.formatEquals(
+        "{{ foo + 1 }}",
+        "<%= foo + 1 %>"
+      );
+      assert.formatEquals(
+        "{{ foo + 1 + bar }}",
+        "<%= foo + 1 + bar %>"
+      );
+      assert.formatEquals(
+        "{{ foo + 'bar' }}",
+        "<%= foo + 'bar' %>"
+      );
+    });
+
+    describe('subtract', function() {
+      assert.formatEquals(
+        "{{ foo - bar }}",
+        "<%= foo - bar %>"
+      );
+      assert.formatEquals(
+        "{{ foo - 1 }}",
+        "<%= foo - 1 %>"
+      );
+    });
+
+    describe('multiply', function() {
+      assert.formatEquals(
+        "{{ x * 2 }}",
+        "<%= x * 2 %>"
+      );
+      assert.formatEquals(
+        "{{ x * y * 2 }}",
+        "<%= x * y * 2 %>"
+      );
+    });
+
+    describe('divide', function() {
+      assert.formatEquals(
+        "{{ x / 2 }}",
+        "<%= x / 2 %>"
+      );
+      assert.formatEquals(
+        "{{ x / y }}",
+        "<%= x / y %>"
+      );
+    });
+
+    describe('mixed operators', function() {
+      assert.formatEquals(
+        "{{ foo + bar - 1 }}",
+        "<%= foo + bar - 1 %>"
+      );
+      assert.formatEquals(
+        "{{ foo / bar + 2 }}",
+        "<%= foo / bar + 2 %>"
+      );
+      assert.formatEquals(
+        "{{ foo / bar * 2 - 1 }}",
+        "<%= foo / bar * 2 - 1 %>"
+      );
+    });
+
+    describe('parenthesis grouping', function() {
+      assert.formatEquals(
+        "{{ foo + (bar + 1) }}",
+        "<%= foo + (bar + 1) %>"
+      );
+      assert.formatEquals(
+        "{{ foo / (bar + 1) }}",
+        "<%= foo / (bar + 1) %>"
+      );
+    });
+  });
+
+  describe('set local variables', function() {
+    assert.formatEquals(
+      '{% set foo = 1 %}',
+      '<% foo = 1 %>'
+    );
+    assert.formatEquals(
+      '<% foo = x * 2 %>',
+      '<% foo = x * 2 %>'
+    );
+  });
+
+  describe('include nodes', function() {
+    assert.formatEquals(
+      "{% include 'foo' %}",
+      "<%= render partial: 'foo' %>"
+    );
+    assert.formatEquals(
+      "{% include foo.bar %}",
+      "<%= render partial: foo.bar %>"
+    );
+    assert.formatEquals(
+      "{% include foo + '.html' %}",
+      "<%= render partial: foo + '.html' %>"
+    );
+  });
+
+});

--- a/test/erb.spec.js
+++ b/test/erb.spec.js
@@ -79,6 +79,11 @@ describe('default format (nunjucks -> erb)', function() {
       "{% if z %}yes{% else %}{% if y %}maybe{% else %}no{% endif %}{% endif %}",
       "<% if z %>yes<% else %><% if y %>maybe<% else %>no<% end %><% end %>"
     );
+
+    assert.formatEquals(
+      "{% if not foo %}yes{% endif %}",
+      "<% if not foo %>yes<% end %>"
+    );
   });
 
   describe('literals', function() {

--- a/test/handlebars.spec.js
+++ b/test/handlebars.spec.js
@@ -19,6 +19,16 @@ describe('handlebars output', function() {
       assert.formatEquals('{{ x }}', '{{{x}}}');
     });
 
+    describe('formats if conditionals', function() {
+      assert.formatEquals('{% if z %}yes{% endif %}', '{{#if z}}yes{{/if}}');
+      assert.formatEquals('{% if z %}yes{% else %}no{% endif %}', '{{#if z}}yes{{else}}no{{/if}}');
+
+      // comparisons not supported in handlebars :(
+      // assert.formatEquals('{% if z == 'bar' %}yes{% endif %}', '{{#if z}}yes{{/if}}');
+
+      assert.formatEquals('{% if not z %}yes{% endif %}', '{{^if z}}yes{{/if}}');
+    });
+
     describe('nested properties', function() {
       assert.formatEquals('{{ x.y }}', '{{{x.y}}}');
       assert.formatEquals('{{ x[0] }}', '{{{x.[0]}}}');

--- a/test/nunjucks.spec.js
+++ b/test/nunjucks.spec.js
@@ -57,6 +57,9 @@ describe('default format (nunjucks -> nunjucks)', function() {
       "{% if z %}yes{% elseif y %}maybe{% else %}no{% endif %}",
       "{% if z %}yes{% else %}{% if y %}maybe{% else %}no{% endif %}{% endif %}"
     );
+    assertFormats([
+      "{% if not foo %}yes{% endif %}"
+    ]);
   });
 
   describe('literals', function() {


### PR DESCRIPTION
Covers basic ERB functionality (see spec for details). Notable bits:

- Filters will work assuming there is an equivalent ruby-method/rails
helper in scope. Technically functional, but needs thought if used for real.
- I've ignored blocks as there's not a direct parallel in ERB and the semantics
of `content_for` in Rails are slightly different.

I'm going to continue looking a blocks, as we use them heavily in our [shared layout](https://github.com/alphagov/govuk_template/blob/master/source/views/layouts/govuk_template.html.erb), but I wanted to get a basic PR first 👍 