### PR TITLE
Allow aliasing of filter names in ERB format

### DIFF
--- a/format/erb.js
+++ b/format/erb.js
@@ -13,8 +13,9 @@ const Include = function(node) {
 };
 
 const Filter = function(node) {
+  const name = this.filterAliasMap[node.name.value] || node.name.value;
   return [
-      this.node(node.name),
+      name,
       '(',
       node.args.children.map(arg => this.node(arg)).join(', '),
       ')'
@@ -70,6 +71,10 @@ module.exports = formatFactory({
 
   quote:        abs.quote,
   accessor:     abs.accessor,
+
+  filterAliasMap: {
+    'safe': 'raw'
+  },
 
   Add:          abs.Operator('+'),
   Compare:      abs.Compare,

--- a/test/erb.spec.js
+++ b/test/erb.spec.js
@@ -43,6 +43,13 @@ describe('default format (nunjucks -> erb)', function() {
       "foo {{ bar | qux(1, 'quux', bar.baz[0]) }} baz",
       "foo <%= qux(bar, 1, 'quux', bar.baz[0]) %> baz"
     );
+
+    describe('filter aliases', function() {
+      assert.formatEquals(
+        "foo {{ bar | safe }} baz",
+        "foo <%= raw(bar) %> baz"
+      );
+    });
   });
 
   describe('formats for..in loops', function() {


### PR DESCRIPTION
Some of the builtin Nunjucks filters exist in a ERB (well, Rails) context, but with a different name.

Add a way to alias the filter names, only doing `safe` => `raw` for now, as that's what [we're needing at the moment](https://github.com/alphagov/govuk_frontend_alpha/pull/96/files#diff-48b08d99372b34bace20d226b25b74c2R4) - and is closer to a template language level construct than a filter imo.

This duplicates some similar behaviour in the liquid templates. I didn't want to generalise _quite_ yet, but could be built on in the future.