### PR TITLE
Round out PHP features, add tests

### DIFF
--- a/format/erb.js
+++ b/format/erb.js
@@ -73,7 +73,7 @@ module.exports = formatFactory({
   accessor:     abs.accessor,
 
   filterAliasMap: {
-    'safe': 'raw'
+    'safe': 'raw',
   },
 
   literalAliases: {

--- a/format/php.js
+++ b/format/php.js
@@ -13,7 +13,8 @@ const If = function(node) {
   if (node.else_) {
     // TODO: produce elseif expressions, rather than nested if/else
     parts.push(
-      this.C_OPEN, 'else:', this.WS,
+      this.C_OPEN, this.WS,
+      'else:', this.WS,
       this.C_CLOSE,
       this.node(node.else_)
     );
@@ -84,15 +85,19 @@ module.exports = formatFactory({
   quote:        abs.quote,
   accessor:     accessor,
 
+  Add:          abs.Operator('+'),
   Compare:      abs.Compare,
+  Div:          abs.Operator('/'),
   If:           If,
   Filter:       Filter,
   For:          For,
   Literal:      abs.Literal,
   LookupVal:    abs.LookupVal,
+  Mul:          abs.Operator('*'),
   NodeList:     abs.NodeList,
   Output:       abs.Output,
   Root:         abs.NodeList,
+  Sub:          abs.Operator('-'),
   Symbol:       Symbol,
   TemplateData: abs.TemplateData
 });

--- a/format/php.js
+++ b/format/php.js
@@ -29,10 +29,10 @@ const For = function(node) {
   const parts = [
     this.C_OPEN, this.WS,
     'foreach (',
-    this.node(node.arr), this.WS,
-    'in', this.WS,
     this.node(node.name),
-    ')', this.WS,
+    this.WS, 'in', this.WS,
+    this.node(node.arr),
+    '):', this.WS,
     this.C_CLOSE
   ];
 
@@ -46,20 +46,19 @@ const For = function(node) {
   ]).join('');
 };
 
-const Symbol = function(node) {
-  const prefix = node.parent && ast.getNodeType(node.parent) === 'Filter'
-    ? ''
-    : this.VAR_PREFIX;
-  return prefix + node.value;
+const Symbol = function(node, variable) {
+  return variable === false
+    ? node.value
+    : this.VAR_PREFIX + node.value;
 };
 
 const Filter = function(node) {
   // XXX: render as a Call expression?
   const args = node.args.children;
   return [
-    this.node(node.name, node),
+    this.Symbol(node.name, false),
     '(',
-    args.map(arg => this.node(arg, node)).join(', '),
+    args.map(arg => this.node(arg)).join(', '),
     ')'
   ].join('');
 };

--- a/test/erb.spec.js
+++ b/test/erb.spec.js
@@ -3,9 +3,7 @@ const format = require('../format');
 const path = require('path');
 const runSpec = require('./lib/run-spec');
 
-describe('ERB format', function() {
-  runSpec(
-    path.join(__dirname, 'erb.spec.yml'),
-    format.erb
-  );
-});
+runSpec(
+  path.join(__dirname, 'erb.spec.yml'),
+  format.erb
+);

--- a/test/handlebars.spec.js
+++ b/test/handlebars.spec.js
@@ -3,9 +3,7 @@ const format = require('../format');
 const path = require('path');
 const runSpec = require('./lib/run-spec');
 
-describe('handlebars format', function() {
-  runSpec(
-    path.join(__dirname, 'handlebars.spec.yml'),
-    format.handlebars
-  );
-});
+runSpec(
+  path.join(__dirname, 'handlebars.spec.yml'),
+  format.handlebars
+);

--- a/test/jinja.spec.js
+++ b/test/jinja.spec.js
@@ -3,9 +3,7 @@ const format = require('../format');
 const path = require('path');
 const runSpec = require('./lib/run-spec');
 
-describe('Jinja2 ("jinja") format', function() {
-  runSpec(
-    path.join(__dirname, 'jinja.spec.yml'),
-    format.jinja
-  );
-});
+runSpec(
+  path.join(__dirname, 'jinja.spec.yml'),
+  format.jinja
+);

--- a/test/lib/run-spec.js
+++ b/test/lib/run-spec.js
@@ -95,8 +95,8 @@ const methods = {
    * @return {void}
    */
   converts: (conv) => {
-    const test = (input, output) => {
-      it(`converts: "${input}"`, function() {
+    const test = (input, output, pending) => {
+      (pending ? xit : it)(`converts: "${input}"`, function() {
         assert.equal(
           this.format(parseString(input)),
           output
@@ -104,8 +104,8 @@ const methods = {
       });
     };
 
-    if (Array.isArray(conv)) {
-      conv.forEach(io => test(io.from, io.to));
+    if (conv.from || conv.to || conv.pending) {
+      test(conv.from, conv.to, conv.pending);
     } else {
       Object.keys(conv).forEach(input => {
         test(input, conv[input]);

--- a/test/liquid.spec.js
+++ b/test/liquid.spec.js
@@ -3,9 +3,7 @@ const format = require('../format');
 const path = require('path');
 const runSpec = require('./lib/run-spec');
 
-describe('Liquid format', function() {
-  runSpec(
-    path.join(__dirname, 'liquid.spec.yml'),
-    format.liquid
-  );
-});
+runSpec(
+  path.join(__dirname, 'liquid.spec.yml'),
+  format.liquid
+);

--- a/test/nunjucks.spec.js
+++ b/test/nunjucks.spec.js
@@ -3,9 +3,7 @@ const format = require('../format');
 const path = require('path');
 const runSpec = require('./lib/run-spec');
 
-describe('nunjucks (noop)', function() {
-  runSpec(
-    path.join(__dirname, 'nunjucks.spec.yml'),
-    format.nunjucks
-  );
-});
+runSpec(
+  path.join(__dirname, 'nunjucks.spec.yml'),
+  format.nunjucks
+);

--- a/test/php.spec.js
+++ b/test/php.spec.js
@@ -1,0 +1,9 @@
+'use strict';
+const format = require('../format');
+const path = require('path');
+const runSpec = require('./lib/run-spec');
+
+runSpec(
+  path.join(__dirname, 'php.spec.yml'),
+  format.php
+);

--- a/test/php.spec.yml
+++ b/test/php.spec.yml
@@ -92,25 +92,33 @@ tests:
           to:   '<?= $x == NULL ?>'
 
   - name: 'builtin filter name aliases'
-    pending: true
     converts:
-      '{{ x | striptags }}': '{{ x | strip_html }}'
-      '{{ x | urlencode }}': '{{ x | url_encode }}'
-      '{{ x | upper }}': '{{ x | upcase }}'
-      '{{ x | lower }}': '{{ x | downcase }}'
-      '{{ x | title }}': '{{ x | capitalize }}'
-      '{{ x | nl2br }}': '{{ x | newline_to_br }}'
+      - from: '{{ x | striptags }}'
+        to:   '<?= strip_tags($x) ?>'
+      - from: '{{ x | urlencode }}'
+        to:   '<?= urlencode($x) ?>'
+      - from: '{{ x | upper }}'
+        to:   '<?= strtoupper($x) ?>'
+      - from: '{{ x | lower }}'
+        to:   '<?= strtolower($x) ?>'
+      - from: '{{ x | nl2br }}'
+        to:   '<?= nl2br($x) ?>'
+      - from: '{{ x | title }}'
+        pending: true
 
   - name: 'set node conversion'
-    pending: true
     tests:
 
       - name: 'subs set for assign'
         converts:
-          '{% set foo = 1 %}': '{% assign foo = 1 %}'
-          '{% set foo = x * 2 %}': '{% assign foo = x | times: 2 %}'
+          - from: '{% set foo = 1 %}'
+            to:   '<?php $foo = 1; ?>'
+          - from: '{% set foo = x * 2 %}'
+            to:   '<?php $foo = $x * 2; ?>'
 
       - name: 'uses capture when there is no assignment'
         converts:
-          '{% set foo %}1{% endset %}': '{% capture foo %}1{% endcapture %}'
-          '{% set foo %}{{ x * 2 }}{% endset %}': '{% capture foo %}{{ x | times: 2 }}{% endcapture %}'
+          - from: '{% set foo %}x{% endset %}'
+            to:   '<?php ob_start(PHP_OUTPUT_HANDLER_FLUSHABLE); ?>x<?php $foo = ob_get_flush(); ?>'
+          - from: '{% set foo %}x * 2 = {{ x * 2 }}{% endset %}'
+            to:   '<?php ob_start(PHP_OUTPUT_HANDLER_FLUSHABLE); ?>x * 2 = <?= $x * 2 ?><?php $foo = ob_get_flush(); ?>'

--- a/test/php.spec.yml
+++ b/test/php.spec.yml
@@ -1,0 +1,111 @@
+name: PHP
+
+tests:
+
+  - name: 'formats output expressions'
+    converts:
+      - from: "foo {{ bar }} baz"
+        to:   "foo <?= $bar ?> baz"
+      - from: "foo {{ bar }} baz {{ qux[0] }}"
+        to:   "foo <?= $bar ?> baz <?= $qux[0] ?>"
+      - from: "foo {{ bar['baz qux'][1].x }}"
+        to:   "foo <?= $bar['baz qux'][1]['x'] ?>"
+
+  - name: 'formats filter tags'
+    converts:
+      - from: "foo {{ bar | qux }} baz"
+        to:   "foo <?= qux($bar) ?> baz"
+      - from: "foo {{ bar | qux(1) }} baz"
+        to:   "foo <?= qux($bar, 1) ?> baz"
+      - from: "foo {{ bar | qux(1, 'quux', bar.baz[0]) }} baz"
+        to:   "foo <?= qux($bar, 1, 'quux', $bar['baz'][0]) ?> baz"
+
+  - name: 'formats for..in loops'
+    converts:
+      - from: "{% for x in items %}la {{ x[0] }}{% endfor %}"
+        to:   "<?php foreach ($x in $items): ?>la <?= $x[0] ?><?php endforeach; ?>"
+      - from: "{% for x in items.x['foo bar'].qux %}la {{ x[0] }}{% endfor %}"
+        to:   "<?php foreach ($x in $items['x']['foo bar']['qux']): ?>la <?= $x[0] ?><?php endforeach; ?>"
+
+  - name: 'formats if conditionals'
+    converts:
+      - from: "{% if z %}yes{% endif %}"
+        to:   "<?php if ($z): ?>yes<?php endif; ?>"
+      - from: "{% if z == 'bar' %}yes{% endif %}"
+        to:   ""
+        pending: true
+      - from: "{% if z %}yes{% else %}no{% endif %}"
+        to:   ""
+        pending: true
+      - from: "{% if z %}yes{% elif y %}maybe{% else %}no{% endif %}"
+        to:   "{% if z %}yes{% else %}{% if y %}maybe{% else %}no{% endif %}{% endif %}"
+        pending: true
+
+  - name: 'simple operators'
+    pending: true
+    tests:
+
+    - name: 'add'
+      converts:
+        '{{ x + 1 }}': '{{ x | plus: 1 }}'
+        '{{ x + 1 + y }}': '{{ x | plus: 1 | plus: y }}'
+
+    - name: 'subtract'
+      converts:
+        '{{ x - 1 }}': '{{ x | minus: 1 }}'
+        '{{ x - y - 1 }}': '{{ x | minus: y | minus: 1 }}'
+
+    - name: 'multiply'
+      converts:
+        '{{ x * 2 }}': '{{ x | times: 2 }}'
+        '{{ x * y * 2 }}': '{{ x | times: y | times: 2 }}'
+
+    - name: 'divide'
+      converts:
+        '{{ x / 2 }}': '{{ x | divided_by: 2 }}'
+        '{{ x / y }}': '{{ x | divided_by: y }}'
+
+    - name: 'mixed operators'
+      converts:
+        '{{ x - 1 + y }}': '{{ x | minus: 1 | plus: y }}'
+        '{{ x / 2 + y }}': '{{ x | divided_by: 2 | plus: y }}'
+
+  - name: 'comparator conversion'
+    pending: true
+    tests:
+
+      - name: 'replaces === with =='
+        converts:
+          '{{ x === 1 }}': '{{ x == 1 }}'
+
+  - name: 'symbol aliases'
+    pending: true
+    tests:
+
+      - name: 'replaces null with nil'
+        converts:
+          '{{ x == null }}': '{{ x == nil }}'
+
+  - name: 'builtin filter name aliases'
+    pending: true
+    converts:
+      '{{ x | striptags }}': '{{ x | strip_html }}'
+      '{{ x | urlencode }}': '{{ x | url_encode }}'
+      '{{ x | upper }}': '{{ x | upcase }}'
+      '{{ x | lower }}': '{{ x | downcase }}'
+      '{{ x | title }}': '{{ x | capitalize }}'
+      '{{ x | nl2br }}': '{{ x | newline_to_br }}'
+
+  - name: 'set node conversion'
+    pending: true
+    tests:
+
+      - name: 'subs set for assign'
+        converts:
+          '{% set foo = 1 %}': '{% assign foo = 1 %}'
+          '{% set foo = x * 2 %}': '{% assign foo = x | times: 2 %}'
+
+      - name: 'uses capture when there is no assignment'
+        converts:
+          '{% set foo %}1{% endset %}': '{% capture foo %}1{% endcapture %}'
+          '{% set foo %}{{ x * 2 }}{% endset %}': '{% capture foo %}{{ x | times: 2 }}{% endcapture %}'

--- a/test/php.spec.yml
+++ b/test/php.spec.yml
@@ -77,20 +77,19 @@ tests:
           to:   '<?= $x / 2 + $y ?>'
 
   - name: 'comparator conversion'
-    pending: true
     tests:
-
-      - name: 'replaces === with =='
+      - name: 'preserves ==='
         converts:
-          '{{ x === 1 }}': '{{ x == 1 }}'
+          from: '{{ x === 1 }}'
+          to:   '<?= $x === 1 ?>'
 
   - name: 'symbol aliases'
-    pending: true
     tests:
 
-      - name: 'replaces null with nil'
+      - name: 'replaces null with NULL'
         converts:
-          '{{ x == null }}': '{{ x == nil }}'
+          from: '{{ x == null }}'
+          to:   '<?= $x == NULL ?>'
 
   - name: 'builtin filter name aliases'
     pending: true

--- a/test/php.spec.yml
+++ b/test/php.spec.yml
@@ -32,43 +32,49 @@ tests:
       - from: "{% if z %}yes{% endif %}"
         to:   "<?php if ($z): ?>yes<?php endif; ?>"
       - from: "{% if z == 'bar' %}yes{% endif %}"
-        to:   ""
-        pending: true
+        to:   "<?php if ($z == 'bar'): ?>yes<?php endif; ?>"
       - from: "{% if z %}yes{% else %}no{% endif %}"
-        to:   ""
-        pending: true
+        to:   "<?php if ($z): ?>yes<?php else: ?>no<?php endif; ?>"
       - from: "{% if z %}yes{% elif y %}maybe{% else %}no{% endif %}"
-        to:   "{% if z %}yes{% else %}{% if y %}maybe{% else %}no{% endif %}{% endif %}"
-        pending: true
+        to:   "<?php if ($z): ?>yes<?php else: ?><?php if ($y): ?>maybe<?php else: ?>no<?php endif; ?><?php endif; ?>"
 
   - name: 'simple operators'
-    pending: true
     tests:
 
     - name: 'add'
       converts:
-        '{{ x + 1 }}': '{{ x | plus: 1 }}'
-        '{{ x + 1 + y }}': '{{ x | plus: 1 | plus: y }}'
+        - from: '{{ x + 1 }}'
+          to:   '<?= $x + 1 ?>'
+        - from: '{{ x + 1 + y }}'
+          to:   '<?= $x + 1 + $y ?>'
 
     - name: 'subtract'
       converts:
-        '{{ x - 1 }}': '{{ x | minus: 1 }}'
-        '{{ x - y - 1 }}': '{{ x | minus: y | minus: 1 }}'
+        - from: '{{ x - 1 }}'
+          to:   '<?= $x - 1 ?>'
+        - from: '{{ x - y - 1 }}'
+          to:   '<?= $x - $y - 1 ?>'
 
     - name: 'multiply'
       converts:
-        '{{ x * 2 }}': '{{ x | times: 2 }}'
-        '{{ x * y * 2 }}': '{{ x | times: y | times: 2 }}'
+        - from: '{{ x * 2 }}'
+          to:   '<?= $x * 2 ?>'
+        - from: '{{ x * y * 2 }}'
+          to:   '<?= $x * $y * 2 ?>'
 
     - name: 'divide'
       converts:
-        '{{ x / 2 }}': '{{ x | divided_by: 2 }}'
-        '{{ x / y }}': '{{ x | divided_by: y }}'
+        - from: '{{ x / 2 }}'
+          to:   '<?= $x / 2 ?>'
+        - from: '{{ x / y }}'
+          to:   '<?= $x / $y ?>'
 
     - name: 'mixed operators'
       converts:
-        '{{ x - 1 + y }}': '{{ x | minus: 1 | plus: y }}'
-        '{{ x / 2 + y }}': '{{ x | divided_by: 2 | plus: y }}'
+        - from: '{{ x - 1 + y }}'
+          to:   '<?= $x - 1 + $y ?>'
+        - from: '{{ x / 2 + y }}'
+          to:   '<?= $x / 2 + $y ?>'
 
   - name: 'comparator conversion'
     pending: true


### PR DESCRIPTION
Hey, now we can do really basic stuff with PHP... Hooray?

Anyway, there's a PHP test suite now that passes most of the stuff. (The only pending test is the `title` filter, which there isn't a built-in PHP function for, and I'm not sure whether that should fail out of the box.)

One other change I've made here is to remove the explicit outer `describe()` calls in the format specs, because those are now generated by the `name` field in the corresponding YAML files.