### PR TITLE
Use Bundler for Ruby dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,1 @@
+gem 'liquid-cli'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,14 @@
+GEM
+  specs:
+    liquid (3.0.6)
+    liquid-cli (0.0.1)
+      liquid
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  liquid-cli
+
+BUNDLED WITH
+   1.13.6

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Transform Nunjucks templates into other formats",
   "main": "index.js",
   "scripts": {
+    "postinstall": "bundle",
     "test": "mocha test/**/*.spec.js",
     "build": "browserify src/bundle.js --debug -t [ babelify --presets [ es2015 ] ] | uglifyjs --source-map-inline | exorcist dist/meta-template.js.map > dist/meta-template.js"
   },

--- a/test/bin/liquid
+++ b/test/bin/liquid
@@ -1,2 +1,2 @@
 #!/bin/sh
-echo "${1}" | liquid "${2}"
+echo "${1}" | bundle exec liquid "${2}"


### PR DESCRIPTION
This adds a `Gemfile` that references the [liquid-cli](https://github.com/pbrisbin/liquid-cli) Gem and updates the Liquid integration test script to use `bundle exec liquid` instead of just `liquid` (which assumes a globally installed Gem). We also run `bundle` to install dependencies in the npm `postinstall` hook, which should work on CI services.