### PR TITLE
Clean up the CLI

### DIFF
--- a/bin/parse.js
+++ b/bin/parse.js
@@ -1,13 +1,39 @@
 #!/usr/bin/env node
 'use strict';
 
-const yargs = require('yargs');
-const options = yargs
-  .alias('c', 'clean')
+const yargs = require('yargs')
+  .usage('$0 [options] [template.njk]')
+  .describe('format', 'Set the output format (default: output AST as JSON)')
   .alias('f', 'format')
+  .describe('trim', 'Trim whitespace from input')
   .alias('t', 'trim')
+  .describe('verbose', 'Output verbose debugging info to stderr')
   .alias('v', 'verbose')
-  .argv;
+  .describe('clean', 'Remove line and column numbers from AST output')
+  .alias('c', 'clean')
+  .alias('h', 'help');
+
+const options = yargs.argv;
+
+if (options.help) {
+  yargs.showHelp();
+  const formats = [
+    'AST (Abstract Syntax Tree, JSON, default)',
+    'nunjucks',
+    'liquid',
+    'jekyll',
+    'jinja',
+    'handlebars',
+    'erb',
+    'php',
+  ];
+  const sep = '\n  - ';
+  process.stdout.write(
+    'Available output formats are: ' + sep + formats.join(sep) + '\n'
+  );
+  return;
+}
+
 const args = options._;
 
 const concat = require('concat-stream');

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "description": "Transform Nunjucks templates into other formats",
   "main": "index.js",
+  "bin": {
+    "meta-template": "bin/parse.js"
+  },
   "scripts": {
     "postinstall": "bundle",
     "test": "mocha test/**/*.spec.js",


### PR DESCRIPTION
This exports a binary, `meta-template`, from the npm installation; and adds help output (`meta-template --help`).